### PR TITLE
Resolve parameter ordering, remove extra params

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -53,12 +53,11 @@ class Request extends Context
                 $this->getConnectOption('login_method', 'AMQPLAIN'),
                 $this->getConnectOption('login_response', null),
                 $this->getConnectOption('locale', 3),
+                $this->getConnectOption('channel_rpc_timeout', 0.0),
                 $this->getConnectOption('read_write_timeout', 130),
                 $this->getConnectOption('context', null),
                 $this->getConnectOption('keepalive', false),
-                $this->getConnectOption('heartbeat', 60),
-                $this->getConnectOption('channel_rpc_timeout', 0.0),
-                $this->getConnectOption('ssl_protocol', null)
+                $this->getConnectOption('heartbeat', 60)
             );
         }
 


### PR DESCRIPTION
The constructor had too many parameters going into it, and some of them were out of order. I have resolved the order as best as I could determine, and removed the ssl_protocol arg that was being dropped on the floor again.